### PR TITLE
fix: better calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     }
   },
   "prettier": "@stacks/prettier-config",
-  "name": "sip-12",
+  "name": "@fungible-systems/sip-12",
   "author": "Hank Stoever",
   "module": "dist/sip-12.esm.js",
   "size-limit": [

--- a/src/common/pox.ts
+++ b/src/common/pox.ts
@@ -7,6 +7,7 @@ import {
   OptionalCV,
   ClarityType,
   cvToHex,
+  contractPrincipalCV,
 } from 'micro-stacks/clarity';
 
 const apiConfig = new Configuration({
@@ -19,13 +20,19 @@ type PoxStackerInfo = {
 };
 
 export async function getStackerData(stxAddress: string) {
+  // to support contract principals
+  const [address, contractName] = stxAddress.split('.');
+  const hex = !!contractName
+    ? cvToHex(contractPrincipalCV(address, contractName))
+    : cvToHex(standardPrincipalCV(stxAddress));
+
   const res = await stacksApi.callReadOnlyFunction({
     contractAddress: 'SP000000000000000000002Q6VF78',
     contractName: 'pox',
     functionName: 'get-stacker-info',
     readOnlyFunctionArgs: {
       sender: 'SP000000000000000000002Q6VF78',
-      arguments: [cvToHex(standardPrincipalCV(stxAddress))],
+      arguments: [hex],
     },
   });
 

--- a/src/common/stacking-club.ts
+++ b/src/common/stacking-club.ts
@@ -1,22 +1,19 @@
-import { CYCLE } from './constants';
+import { VoteTransaction } from './types';
 
-export interface StackerData {
-  stackingTxs: {
-    aggregate: {
-      sum: {
-        amount: number | null;
-      };
-    };
-  };
+async function fetchFromSip12Endpoint(btc_address: string, stx_address: string) {
+  try {
+    const res = await fetch(
+      `https://api.stacking.club/api/sip-12?btc_address=${btc_address}&stx_address=${stx_address}`
+    );
+    const data = await res.json();
+    const amount = data?.amount?.amount;
+    if (amount) return BigInt(amount);
+  } catch (e) {
+    console.error(e);
+  }
+  return null;
 }
 
-export function stackingClubUrl(btcAddress: string) {
-  return `https://api.stacking-club.com/api/stacker-data?variables=${btcAddress}____${CYCLE}`;
-}
-
-export async function getRewardData(btcAddress: string) {
-  const res = await fetch(stackingClubUrl(btcAddress));
-  const stackerData: StackerData = await res.json();
-  const { amount } = stackerData.stackingTxs.aggregate.sum;
-  return amount ? BigInt(amount) : null;
+export async function getStackedAmount(vote: VoteTransaction) {
+  return fetchFromSip12Endpoint(vote.btcAddress, vote.stxAddress);
 }

--- a/src/common/transform.ts
+++ b/src/common/transform.ts
@@ -1,20 +1,12 @@
 import { Vote, VoteTransaction } from './types';
-import { getRewardData } from './stacking-club';
-import { getStackerData } from './pox';
+import { getStackedAmount } from './stacking-club';
 
 export async function transformVote(vote: VoteTransaction): Promise<Vote> {
-  const [reward, stacker] = await Promise.all([
-    getRewardData(vote.btcAddress),
-    getStackerData(vote.stxAddress),
-  ]);
-
-  let amount = 0n;
-  if (reward) amount = reward;
-  if (stacker) amount = stacker;
+  const amount = await getStackedAmount(vote);
 
   return {
     ...vote,
-    amount: amount.toString(10),
+    amount: amount?.toString(10) || '0',
   };
 }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -19,3 +19,60 @@ export interface VoteData {
     reject: string;
   };
 }
+
+export interface StackerData {
+  stackingTxs: StackingTxs;
+  totalStacked: TotalStacked;
+  blockRewards: BlockRewards;
+}
+
+export interface StackingTxs {
+  nodes?: NodesEntity[] | null;
+  aggregate: Aggregate;
+}
+
+export interface NodesEntity {
+  txid: string;
+  stx_address: string;
+  amount: number;
+  btc_address: string;
+  num_cycles: number;
+  last_cycle: number;
+  is_delegator: boolean;
+  first_cycle: number;
+}
+
+export interface Aggregate {
+  sum: Sum;
+}
+
+export interface Sum {
+  amount: number;
+}
+
+export interface TotalStacked {
+  aggregate: Aggregate;
+}
+
+export interface BlockRewards {
+  aggregate: Aggregate1;
+  nodes?: NodesEntity1[] | null;
+}
+
+export interface Aggregate1 {
+  count: number;
+  avg: AvgOrSum;
+  sum: AvgOrSum;
+}
+
+export interface AvgOrSum {
+  reward_amount: number;
+}
+
+export interface NodesEntity1 {
+  reward_amount: number;
+  reward_index: number;
+  burn_block_height: number;
+  burn_block_hash: string;
+  recipient_address: string;
+}

--- a/src/get-btc-vote-txs.ts
+++ b/src/get-btc-vote-txs.ts
@@ -2,6 +2,10 @@ import { VoteTransaction } from './common/types';
 import { btcToStxAddress, voteTransactionsUrl } from './common/utils';
 import { Tx } from '@mempool/mempool.js/lib/interfaces/bitcoin/transactions';
 
+function dedupe<T>(arr: T[], key: keyof T) {
+  return arr.filter((item, index, self) => index === self.findIndex(t => t[key] === item[key]));
+}
+
 export async function getBTCVoteTransactions(approve: boolean): Promise<VoteTransaction[]> {
   const url = voteTransactionsUrl(approve);
   const response = await fetch(url);
@@ -24,5 +28,5 @@ export async function getBTCVoteTransactions(approve: boolean): Promise<VoteTran
       console.error('Invalid address:', btcAddress);
     }
   });
-  return votes;
+  return dedupe(votes, 'btcAddress');
 }

--- a/test/btc.test.ts
+++ b/test/btc.test.ts
@@ -10,7 +10,7 @@ import {
   NO_VOTE_TXS,
   YES_VOTE_TXS,
 } from './mocks';
-import { stackingClubUrl } from '../src/common/stacking-club';
+import { buildStackingClubUrl } from '../src/common/stacking-club';
 import { btcToStxAddress, voteTransactionsUrl } from '../src/common/utils';
 import { getBTCVoteTransactions } from '../src/get-btc-vote-txs';
 import { getVoteData } from '../src/get-vote-data';
@@ -55,11 +55,11 @@ test.only('can get full data', async () => {
   });
 
   fetchMock.get(
-    stackingClubUrl('31tXY8LMEcc3YzWwpFQj7ZGYE2U2BM1kk4'),
+    buildStackingClubUrl('31tXY8LMEcc3YzWwpFQj7ZGYE2U2BM1kk4'),
     makeStackerDataResponse(null)
   );
   fetchMock.get(
-    stackingClubUrl('1LoPvZSimetbef4Lg28ivi9hnEek6Fr9Z4'),
+    buildStackingClubUrl('1LoPvZSimetbef4Lg28ivi9hnEek6Fr9Z4'),
     makeStackerDataResponse(200)
   );
 

--- a/test/mocks.ts
+++ b/test/mocks.ts
@@ -1,5 +1,5 @@
 import { noneCV, serializeCV, someCV, tupleCV, uintCV } from 'micro-stacks/clarity';
-import { StackerData } from '../src/common/stacking-club';
+import { StackerData } from '../src';
 
 function makeTx(address: string) {
   return {
@@ -44,5 +44,5 @@ export function makeStackerDataResponse(amount: number | null): StackerData {
         },
       },
     },
-  };
+  } as StackerData;
 }


### PR DESCRIPTION
This tries to improve the way we were calculating the total stacked amount per vote. Previously we were using the stacked amounts from the stacking.club api. I've change it to only get the STX address associated with a given vote, and then use the read only contract calls to fetch the stacking amount. 

Additionally i've made it so we are fetching amounts for the previous cycle if there are no stacked amounts for the current cycle.