### PR TITLE
feat: use new stacking club endpoint

### DIFF
--- a/src/common/stacking-club.ts
+++ b/src/common/stacking-club.ts
@@ -1,22 +1,19 @@
-import { CYCLE } from './constants';
+import { VoteTransaction } from './types';
 
-export interface StackerData {
-  stackingTxs: {
-    aggregate: {
-      sum: {
-        amount: number | null;
-      };
-    };
-  };
+async function fetchFromSip12Endpoint(btc_address: string, stx_address: string) {
+  try {
+    const res = await fetch(
+      `https://api.stacking.club/api/sip-12?btc_address=${btc_address}&stx_address=${stx_address}`
+    );
+    const data = await res.json();
+    const amount = data?.amount?.amount;
+    if (amount) return BigInt(amount);
+  } catch (e) {
+    console.error(e);
+  }
+  return null;
 }
 
-export function stackingClubUrl(btcAddress: string) {
-  return `https://api.stacking-club.com/api/stacker-data?variables=${btcAddress}____${CYCLE}`;
-}
-
-export async function getRewardData(btcAddress: string) {
-  const res = await fetch(stackingClubUrl(btcAddress));
-  const stackerData: StackerData = await res.json();
-  const { amount } = stackerData.stackingTxs.aggregate.sum;
-  return amount ? BigInt(amount) : null;
+export async function getStackedAmount(vote: VoteTransaction) {
+  return fetchFromSip12Endpoint(vote.btcAddress, vote.stxAddress);
 }

--- a/src/common/transform.ts
+++ b/src/common/transform.ts
@@ -1,20 +1,12 @@
 import { Vote, VoteTransaction } from './types';
-import { getRewardData } from './stacking-club';
-import { getStackerData } from './pox';
+import { getStackedAmount } from './stacking-club';
 
 export async function transformVote(vote: VoteTransaction): Promise<Vote> {
-  const [reward, stacker] = await Promise.all([
-    getRewardData(vote.btcAddress),
-    getStackerData(vote.stxAddress),
-  ]);
-
-  let amount = 0n;
-  if (reward) amount = reward;
-  if (stacker) amount = stacker;
+  const amount = await getStackedAmount(vote);
 
   return {
     ...vote,
-    amount: amount.toString(10),
+    amount: BigInt(amount || 0).toString(10),
   };
 }
 

--- a/test/btc.test.ts
+++ b/test/btc.test.ts
@@ -4,13 +4,7 @@ import { TextDecoder, TextEncoder } from 'util';
 global.TextDecoder = TextDecoder;
 global.TextEncoder = TextEncoder;
 import fetchMock from 'fetch-mock-jest';
-import {
-  makeStackerDataResponse,
-  makeStackerInfoResponse,
-  NO_VOTE_TXS,
-  YES_VOTE_TXS,
-} from './mocks';
-import { stackingClubUrl } from '../src/common/stacking-club';
+import { makeStackerInfoResponse, NO_VOTE_TXS, YES_VOTE_TXS } from './mocks';
 import { btcToStxAddress, voteTransactionsUrl } from '../src/common/utils';
 import { getBTCVoteTransactions } from '../src/get-btc-vote-txs';
 import { getVoteData } from '../src/get-vote-data';
@@ -53,15 +47,6 @@ test.only('can get full data', async () => {
     }
     return makeStackerInfoResponse(null);
   });
-
-  fetchMock.get(
-    stackingClubUrl('31tXY8LMEcc3YzWwpFQj7ZGYE2U2BM1kk4'),
-    makeStackerDataResponse(null)
-  );
-  fetchMock.get(
-    stackingClubUrl('1LoPvZSimetbef4Lg28ivi9hnEek6Fr9Z4'),
-    makeStackerDataResponse(200)
-  );
 
   const data = await getVoteData();
   expect(data.totals.support).toEqual('1000');

--- a/test/stacking-club.test.ts
+++ b/test/stacking-club.test.ts
@@ -7,7 +7,6 @@ import fetchMock from 'fetch-mock-jest';
 import 'cross-fetch/polyfill';
 import { getStackerData } from '../src/common/pox';
 import { makeStackerDataResponse, makeStackerInfoResponse } from './mocks';
-import { getRewardData } from '../src';
 
 test.skip('testing pox data', async () => {
   const result = await getStackerData('SMJ2T5JRTD9XV9KF8MA1YBX71TNKJJ0M73HDDAZ9');
@@ -24,10 +23,8 @@ test('getting stacks address information', async () => {
   expect(await getStackerData('SMJ2T5JRTD9XV9KF8MA1YBX71TNKJJ0M73HDDAZ9')).toEqual(null);
 
   fetchMock.getOnce('begin:https://api.stacking-club', makeStackerDataResponse(null));
-  expect(await getRewardData('SMJ2T5JRTD9XV9KF8MA1YBX71TNKJJ0M73HDDAZ9')).toEqual(null);
 
   fetchMock.getOnce('begin:https://api.stacking-club', makeStackerDataResponse(4000), {
     overwriteRoutes: true,
   });
-  expect(await getRewardData('SMJ2T5JRTD9XV9KF8MA1YBX71TNKJJ0M73HDDAZ9')).toEqual(4000n);
 });


### PR DESCRIPTION
This uses a new stacking.club endpoint that returns an aggregate value of stacks locked for the two cycles we care about: 19,20. You can pass both a BTC and STX address to check either of them.